### PR TITLE
Footer Info Position Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     </p>
   </section>
 
-  <div posi>
+  <div class="footerPlaceHolder">
     <p>
       <!-- <img src="/resources/copyright.png" alt="Da Copyright Icon"> -->
       <b class=copyright> Website made by Jorge B, 2020-2021</b>

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,12 @@ a:visited {
   bottom: 1px;
 }
 
+.footerPlaceHolder {
+  position: absolute;
+  bottom: 0;
+  width: 100vw;
+}
+
 .material-icons {
   font-family: 'Material Icons';
   font-weight: normal;
@@ -46,7 +52,7 @@ a:visited {
   word-wrap: normal;
   white-space: nowrap;
   direction: ltr;
-
+    
   /* Support for all WebKit browsers. */
   -webkit-font-smoothing: antialiased;
   /* Support for Safari and Chrome. */


### PR DESCRIPTION
Moves the "copyright" text to the bottom of the body, while preserving horizontal text positioning.